### PR TITLE
Fixes bmuschko/gradle-vagrant-plugin#3 - Changing OsUtils to include all of the inherited environment variables.

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/vagrant/utils/OsUtils.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/vagrant/utils/OsUtils.groovy
@@ -26,25 +26,12 @@ final class OsUtils {
     }
 
     static List<String> prepareEnvVars(Map<String, String> providedEnvVars) {
-        providedEnvVars[VAGRANT_HOME_ENV_VAR] = determineVagrantHome()
-        flattenEnvVars(providedEnvVars)
-    }
-
-    private static String determineVagrantHome() {
-        String vagrantHome = System.getenv()[VAGRANT_HOME_ENV_VAR]
-
-        if(!vagrantHome) {
-            String userProfile = System.getenv()[USERPROFILE_ENV_VAR]
-
-            if(userProfile) {
-                vagrantHome = "$userProfile/.vagrant.d"
-            }
-            else {
-                vagrantHome = "${System.properties['user.home']}/.vagrant.d"
-            }
-        }
-
-        vagrantHome
+        def allEnvVars = [:]
+        // Get all of the inherited environment variables.
+        allEnvVars.putAll(System.getenv())
+        // Apply the overrides and additions.
+        allEnvVars.putAll(providedEnvVars)
+        flattenEnvVars(allEnvVars)
     }
 
     private static List<String> flattenEnvVars(Map<String, String> providedEnvVars) {


### PR DESCRIPTION
I tested it on Windows and found that when I did set an environment variable vagrant would no longer execute. By passing in environment variables to execute() the gradle process's environment variables were no longer being inherited by the command being executed.

Here's the output I was seeing:

> Executing external command: 'cmd /c vagrant box list' with environment variables [IP=192.168.1.33, OPERATINGSYSTEM=redhat, VAGRANT_HOME=C:\Users\akroh/.vagrant.d]
> 'vagrant' is not recognized as an internal or external command, operable program or batch file.
