### PR TITLE
Update plugin for Gradle 7.0

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -58,9 +58,9 @@ The base plugin defines the following extension properties in the `vagrant` clos
 
 [options="header"]
 |=======
-|Property name   |Type      |Default value          |Description
-|`boxDir`        |File      |`project.projectDir`   |The directory the targeted Vagrant box resides in.
-|`provider`      |String    |virtualbox             |The link:http://docs.vagrantup.com/v2/providers/index.html[backend provider] to be used.
+|Property name   |Type      |Default value               |Description
+|`boxDir`        |File      |`project.file("vagrant")`   |The directory the targeted Vagrant box resides in.
+|`provider`      |String    |virtualbox                  |The link:http://docs.vagrantup.com/v2/providers/index.html[backend provider] to be used.
 |=======
 
 The recommended way for providing values to the `Vagrantfile` from the outside is to use environment variables. This is made

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/VagrantBasePlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/VagrantBasePlugin.groovy
@@ -53,7 +53,7 @@ class VagrantBasePlugin implements Plugin<Project> {
 
     private File getBoxDir(Project project) {
         File boxDir = project.hasProperty('boxDir') ? project.file(project.boxDir) : project.extensions.findByName(EXTENSION_NAME).boxDir
-        boxDir ?: project.projectDir
+        boxDir ?: project.file("vagrant")
     }
 
     private String getProvider(Project project) {

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
@@ -23,6 +23,10 @@ import com.bmuschko.gradle.vagrant.utils.OsUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 class Vagrant extends DefaultTask {
@@ -37,7 +41,8 @@ class Vagrant extends DefaultTask {
     /**
      * The directory the targeted Vagrant box resides in.
      */
-    @Input
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @InputDirectory
     File boxDir
 
     /**
@@ -46,6 +51,7 @@ class Vagrant extends DefaultTask {
     @Input
     Map<String, String> environmentVariables = [:]
 
+    @Internal
     ExternalProcessExecutor processExecutor
 
     Vagrant() {
@@ -66,6 +72,7 @@ class Vagrant extends DefaultTask {
         }
     }
 
+    @Internal
     List<String> getEnvVars() {
         getEnvironmentVariables().size() > 0 ? OsUtils.prepareEnvVars(getEnvironmentVariables()) : null
     }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
@@ -20,6 +20,7 @@ import com.bmuschko.gradle.vagrant.process.ExternalProcessExecutor
 import com.bmuschko.gradle.vagrant.process.ExternalProgram
 import com.bmuschko.gradle.vagrant.process.GDKExternalProcessExecutor
 import com.bmuschko.gradle.vagrant.utils.OsUtils
+import groovy.transform.PackageScope
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
@@ -51,7 +52,8 @@ class Vagrant extends DefaultTask {
     @Input
     Map<String, String> environmentVariables = [:]
 
-    @Internal
+    // visible for testing
+    @PackageScope
     ExternalProcessExecutor processExecutor
 
     Vagrant() {

--- a/src/test/groovy/com/bmuschko/gradle/vagrant/VagrantBasePluginSpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/vagrant/VagrantBasePluginSpec.groovy
@@ -35,7 +35,7 @@ class VagrantBasePluginSpec extends Specification {
         when:
             def task = project.task('myCustomVagrantUp', type: VagrantUp)
         then:
-            task.boxDir == project.projectDir
+            task.boxDir == project.file("vagrant")
     }
 
     def "Box directory is set to value from extension"() {
@@ -128,7 +128,7 @@ class VagrantBasePluginSpec extends Specification {
             project.tasks.findByName('vagrantListsBoxes')
             task.description == 'Outputs a list of available Vagrant boxes.'
             task.commands == ['box', 'list']
-            task.boxDir == project.projectDir
+            task.boxDir == project.file("vagrant")
     }
 
     def "Can create task of type Vagrant with custom values"() {

--- a/src/test/groovy/com/bmuschko/gradle/vagrant/VagrantPluginSpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/vagrant/VagrantPluginSpec.groovy
@@ -50,7 +50,7 @@ class VagrantPluginSpec extends Specification {
             project.tasks.findByName('vagrantUp').commands == ['up']
 
             project.tasks.withType(Vagrant) { task ->
-                assert task.boxDir == project.projectDir
+                assert task.boxDir == project.file("vagrant")
             }
 
             project.tasks.withType(VagrantUp) { task ->


### PR DESCRIPTION
Adds missing `@Internal` annotations to properties that can be ignored
from task input tracking and corrects the declaration for boxDir.