### PR TITLE
Mark options as internal

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
@@ -79,6 +79,7 @@ class Vagrant extends DefaultTask {
         getEnvironmentVariables().size() > 0 ? OsUtils.prepareEnvVars(getEnvironmentVariables()) : null
     }
 
+    @Internal
     List<String> getOptions() {
         []
     }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSsh.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSsh.groovy
@@ -16,6 +16,7 @@
 package com.bmuschko.gradle.vagrant.tasks
 
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 
 class VagrantSsh extends Vagrant {
     /**
@@ -28,6 +29,7 @@ class VagrantSsh extends Vagrant {
         ['ssh']
     }
 
+    @Internal
     @Override
     List<String> getOptions() {
         ['-c', getSshCommand()]

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantUp.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantUp.groovy
@@ -16,6 +16,7 @@
 package com.bmuschko.gradle.vagrant.tasks
 
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 
 class VagrantUp extends Vagrant {
@@ -30,6 +31,7 @@ class VagrantUp extends Vagrant {
         commands = ['up']
     }
 
+    @Internal
     @Override
     List<String> getOptions() {
         getProvider() ? ["--provider=${getProvider()}"] : []


### PR DESCRIPTION
Options is only used by VagrantSsh and VagrantUp and the components
added to the options array are already tracked individually.