### PR TITLE
Use provider API to configure tasks

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/vagrant/VagrantBasePlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/VagrantBasePlugin.groovy
@@ -41,13 +41,13 @@ class VagrantBasePlugin implements Plugin<Project> {
     }
 
     private void configureVagrantTasks(Project project) {
-        project.tasks.withType(Vagrant) {
-            conventionMapping.boxDir = { getBoxDir(project) }
-            conventionMapping.environmentVariables = { project.extensions.findByName(EXTENSION_NAME).environmentVariables.variables }
+        project.tasks.withType(Vagrant).configureEach {
+            it.boxDir.convention(project.objects.directoryProperty().fileValue(getBoxDir(project)))
+            it.environmentVariables.convention(project.extensions.findByName(EXTENSION_NAME).environmentVariables.variables)
         }
 
-        project.tasks.withType(VagrantUp) {
-            conventionMapping.provider = { getProvider(project) }
+        project.tasks.withType(VagrantUp).configureEach {
+            it.provider.convention(getProvider(project))
         }
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
@@ -26,7 +26,12 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 
 abstract class Vagrant extends DefaultTask {
     static final String TASK_GROUP = 'Vagrant'
@@ -37,7 +42,7 @@ abstract class Vagrant extends DefaultTask {
     @Input
     abstract ListProperty<String> getCommands()
 
-    @Internal
+    @Input
     abstract ListProperty<String> getOptions()
 
     /**

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
@@ -28,7 +28,6 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/Vagrant.groovy
@@ -23,34 +23,35 @@ import com.bmuschko.gradle.vagrant.utils.OsUtils
 import groovy.transform.PackageScope
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.tasks.*
 
-class Vagrant extends DefaultTask {
+abstract class Vagrant extends DefaultTask {
     static final String TASK_GROUP = 'Vagrant'
 
     /**
      * The Vagrant command to run.
      */
     @Input
-    List<String> commands
+    abstract ListProperty<String> getCommands()
+
+    @Internal
+    abstract ListProperty<String> getOptions()
 
     /**
      * The directory the targeted Vagrant box resides in.
      */
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputDirectory
-    File boxDir
+    abstract DirectoryProperty getBoxDir()
 
     /**
      * The environment variables passed to Vagrant command.
      */
     @Input
-    Map<String, String> environmentVariables = [:]
+    abstract MapProperty<String, String> getEnvironmentVariables()
 
     // visible for testing
     @PackageScope
@@ -63,24 +64,21 @@ class Vagrant extends DefaultTask {
 
     @TaskAction
     void runCommand() {
-        List<String> vagrantCommands = getCommands()
+        List<String> vagrantCommands = []
+        vagrantCommands.addAll(commands.get())
         vagrantCommands.addAll(0, ExternalProgram.VAGRANT.commandLineArgs)
-        vagrantCommands.addAll(getOptions())
+        vagrantCommands.addAll(options.get())
 
-        ExternalProcessExecutionResult result = processExecutor.execute(vagrantCommands, getEnvVars(), getBoxDir())
+        ExternalProcessExecutionResult result = processExecutor.execute(vagrantCommands, getEnvVars(), boxDir.get().asFile)
 
-        if(!result.isOK()) {
+        if (!result.isOK()) {
             throw new GradleException('Failed to execute the Vagrant command.')
         }
     }
 
-    @Internal
-    List<String> getEnvVars() {
-        getEnvironmentVariables().size() > 0 ? OsUtils.prepareEnvVars(getEnvironmentVariables()) : null
+    private List<String> getEnvVars() {
+        def userSuppliedEnv = environmentVariables.get()
+        return userSuppliedEnv.size() > 0 ? OsUtils.prepareEnvVars(userSuppliedEnv) : null
     }
 
-    @Internal
-    List<String> getOptions() {
-        []
-    }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantDestroy.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantDestroy.groovy
@@ -15,8 +15,8 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
-class VagrantDestroy extends Vagrant {
+abstract class VagrantDestroy extends Vagrant {
     VagrantDestroy() {
-        commands = ['destroy', '--force']
+        commands.set(['destroy', '--force'])
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantHalt.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantHalt.groovy
@@ -15,8 +15,8 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
-class VagrantHalt extends Vagrant {
+abstract class VagrantHalt extends Vagrant {
     VagrantHalt() {
-        commands = ['halt']
+        commands.add('halt')
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantReload.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantReload.groovy
@@ -15,8 +15,8 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
-class VagrantReload extends Vagrant {
+abstract class VagrantReload extends Vagrant {
     VagrantReload() {
-        commands = ['reload']
+        commands.add('reload')
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantResume.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantResume.groovy
@@ -15,8 +15,8 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
-class VagrantResume extends Vagrant {
+abstract class VagrantResume extends Vagrant {
     VagrantResume() {
-        commands = ['resume']
+        commands.add('resume')
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSsh.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSsh.groovy
@@ -15,23 +15,21 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
 
-class VagrantSsh extends Vagrant {
+abstract class VagrantSsh extends Vagrant {
+
+    VagrantSsh() {
+        commands.add("ssh")
+        options.add("-c")
+        options.add(sshCommand)
+    }
+
     /**
      * The remote SSH to execute.
      */
     @Input
-    String sshCommand
+    abstract Property<String> getSshCommand()
 
-    List<String> getCommands() {
-        ['ssh']
-    }
-
-    @Internal
-    @Override
-    List<String> getOptions() {
-        ['-c', getSshCommand()]
-    }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSshConfig.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSshConfig.groovy
@@ -15,8 +15,8 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
-class VagrantSshConfig extends Vagrant {
+abstract class VagrantSshConfig extends Vagrant {
     VagrantSshConfig() {
-        commands = ['ssh-config']
+        commands.add('ssh-config')
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantStatus.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantStatus.groovy
@@ -15,8 +15,8 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
-class VagrantStatus extends Vagrant {
+abstract class VagrantStatus extends Vagrant {
     VagrantStatus() {
-        commands = ['status']
+        commands.add('status')
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSuspend.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSuspend.groovy
@@ -15,8 +15,8 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
-class VagrantSuspend extends Vagrant {
+abstract class VagrantSuspend extends Vagrant {
     VagrantSuspend() {
-        commands = ['suspend']
+        commands.add('suspend')
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantUp.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantUp.groovy
@@ -15,25 +15,21 @@
  */
 package com.bmuschko.gradle.vagrant.tasks
 
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 
-class VagrantUp extends Vagrant {
+abstract class VagrantUp extends Vagrant {
+
+    VagrantUp() {
+        commands.add('up')
+        options.addAll(provider.map { ["--provider=$it"] }.orElse(project.provider { [] }))
+    }
+
     /**
      * The backend provider. Defaults to VirtualBox.
      */
     @Input
     @Optional
-    String provider
-
-    VagrantUp() {
-        commands = ['up']
-    }
-
-    @Internal
-    @Override
-    List<String> getOptions() {
-        getProvider() ? ["--provider=${getProvider()}"] : []
-    }
+    abstract Property<String> getProvider()
 }

--- a/src/test/groovy/com/bmuschko/gradle/vagrant/VagrantBasePluginSpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/vagrant/VagrantBasePluginSpec.groovy
@@ -31,11 +31,11 @@ class VagrantBasePluginSpec extends Specification {
         project.apply plugin: 'com.bmuschko.vagrant-base'
     }
 
-    def "Box directory defaults to project directory if not set"() {
+    def "Box directory defaults to vagrant directory if not set"() {
         when:
             def task = project.task('myCustomVagrantUp', type: VagrantUp)
         then:
-            task.boxDir == project.file("vagrant")
+            task.boxDir.get().asFile == project.file("vagrant")
     }
 
     def "Box directory is set to value from extension"() {
@@ -46,7 +46,7 @@ class VagrantBasePluginSpec extends Specification {
 
             def task = project.task('myCustomVagrantUp', type: VagrantUp)
         then:
-            task.boxDir == project.file('someDir')
+            task.boxDir.get().asFile == project.file('someDir')
     }
 
     def "Box directory is set as property value"() {
@@ -54,14 +54,14 @@ class VagrantBasePluginSpec extends Specification {
             project.ext.boxDir = project.file('other')
             def task = project.task('myCustomVagrantUp', type: VagrantUp)
         then:
-            task.boxDir == project.file('other')
+            task.boxDir.get().asFile == project.file('other')
     }
 
     def "Provider defaults to VirtualBox if not set"() {
         when:
             def task = project.task('myCustomVagrantUp', type: VagrantUp)
         then:
-            task.provider == Provider.VIRTUALBOX.name
+            task.provider.get() == Provider.VIRTUALBOX.name
     }
 
     def "Provider is set to value from extension"() {
@@ -72,7 +72,7 @@ class VagrantBasePluginSpec extends Specification {
 
             def task = project.task('myCustomVagrantUp', type: VagrantUp)
         then:
-            task.provider == 'vmware_fusion'
+            task.provider.get() == 'vmware_fusion'
     }
 
     def "Provider is set as property value"() {
@@ -80,7 +80,7 @@ class VagrantBasePluginSpec extends Specification {
             project.ext.provider = 'vmware_fusion'
             def task = project.task('myCustomVagrantUp', type: VagrantUp)
         then:
-            task.provider == 'vmware_fusion'
+            task.provider.get() == 'vmware_fusion'
     }
 
     @Unroll
@@ -122,28 +122,28 @@ class VagrantBasePluginSpec extends Specification {
         when:
             def task = project.task('vagrantListsBoxes', type: Vagrant) {
                 description = 'Outputs a list of available Vagrant boxes.'
-                commands = ['box', 'list']
+                commands.set(['box', 'list'])
             }
         then:
             project.tasks.findByName('vagrantListsBoxes')
             task.description == 'Outputs a list of available Vagrant boxes.'
-            task.commands == ['box', 'list']
-            task.boxDir == project.file("vagrant")
+            task.commands.get() == ['box', 'list']
+            task.boxDir.get().asFile == project.file("vagrant")
     }
 
     def "Can create task of type Vagrant with custom values"() {
         when:
             def task = project.task('myCustomVagrantUp', type: VagrantUp) {
                 description = 'Brings up Vagrant box.'
-                boxDir = project.file('custom')
-                provider = 'vmware_fusion'
+                boxDir.set(project.layout.projectDirectory.dir('custom'))
+                provider.set('vmware_fusion')
             }
         then:
             project.tasks.findByName('myCustomVagrantUp')
             task.description == 'Brings up Vagrant box.'
-            task.commands == ['up']
-            task.boxDir == project.file('custom')
-            task.provider == 'vmware_fusion'
+            task.commands.get() == ['up']
+            task.boxDir.get().asFile == project.file('custom')
+            task.provider.get() == 'vmware_fusion'
     }
 
     def "Can create multiple tasks of type Vagrant with custom values"() {
@@ -153,23 +153,23 @@ class VagrantBasePluginSpec extends Specification {
 
             def upTask = project.task('fusionBoxUp', type: VagrantUp) {
                 description = 'Brings up Fusion Vagrant box.'
-                boxDir = project.customBoxDir
-                provider = project.fusionProvider
+                boxDir.set(project.customBoxDir)
+                provider.set(project.fusionProvider)
             }
 
             def destroyTask = project.task('fusionBoxDestroy', type: VagrantDestroy) {
                 description = 'Destroys Fusion Vagrant box.'
-                boxDir = project.customBoxDir
+                boxDir.set(project.customBoxDir)
             }
         then:
             project.tasks.findByName('fusionBoxUp')
             upTask.description == 'Brings up Fusion Vagrant box.'
-            upTask.commands == ['up']
-            upTask.boxDir == project.file('custom')
-            upTask.provider == 'vmware_fusion'
+            upTask.commands.get() == ['up']
+            upTask.boxDir.get().asFile == project.file('custom')
+            upTask.provider.get() == 'vmware_fusion'
             project.tasks.findByName('fusionBoxDestroy')
             destroyTask.description == 'Destroys Fusion Vagrant box.'
-            destroyTask.commands == ['destroy', '--force']
-            destroyTask.boxDir == project.file('custom')
+            destroyTask.commands.get() == ['destroy', '--force']
+            destroyTask.boxDir.get().asFile == project.file('custom')
     }
 }

--- a/src/test/groovy/com/bmuschko/gradle/vagrant/VagrantPluginSpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/vagrant/VagrantPluginSpec.groovy
@@ -33,28 +33,28 @@ class VagrantPluginSpec extends Specification {
             project.apply plugin: 'com.bmuschko.vagrant'
         then:
             project.tasks.findByName('vagrantDestroy') != null
-            project.tasks.findByName('vagrantDestroy').commands == ['destroy', '--force']
+            project.tasks.findByName('vagrantDestroy').commands.get() == ['destroy', '--force']
             project.tasks.findByName('vagrantHalt') != null
-            project.tasks.findByName('vagrantHalt').commands == ['halt']
+            project.tasks.findByName('vagrantHalt').commands.get() == ['halt']
             project.tasks.findByName('vagrantReload') != null
-            project.tasks.findByName('vagrantReload').commands == ['reload']
+            project.tasks.findByName('vagrantReload').commands.get() == ['reload']
             project.tasks.findByName('vagrantResume') != null
-            project.tasks.findByName('vagrantResume').commands == ['resume']
+            project.tasks.findByName('vagrantResume').commands.get() == ['resume']
             project.tasks.findByName('vagrantSshConfig') != null
-            project.tasks.findByName('vagrantSshConfig').commands == ['ssh-config']
+            project.tasks.findByName('vagrantSshConfig').commands.get() == ['ssh-config']
             project.tasks.findByName('vagrantStatus') != null
-            project.tasks.findByName('vagrantStatus').commands == ['status']
+            project.tasks.findByName('vagrantStatus').commands.get() == ['status']
             project.tasks.findByName('vagrantSuspend') != null
-            project.tasks.findByName('vagrantSuspend').commands == ['suspend']
+            project.tasks.findByName('vagrantSuspend').commands.get() == ['suspend']
             project.tasks.findByName('vagrantUp') != null
-            project.tasks.findByName('vagrantUp').commands == ['up']
+            project.tasks.findByName('vagrantUp').commands.get() == ['up']
 
             project.tasks.withType(Vagrant) { task ->
-                assert task.boxDir == project.file("vagrant")
+                assert task.boxDir.get().asFile == project.file("vagrant")
             }
 
             project.tasks.withType(VagrantUp) { task ->
-                assert task.provider == Provider.VIRTUALBOX.name
+                assert task.provider.get() == Provider.VIRTUALBOX.name
             }
     }
 }

--- a/src/test/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSpec.groovy
@@ -38,8 +38,8 @@ class VagrantSpec extends Specification {
             ExternalProcessExecutionResult result = new ExternalProcessExecutionResult(exitValue: 1, text: 'failure')
         when:
             Task task = project.task(TASK_NAME, type: Vagrant) {
-                commands = ['box', 'list']
-                boxDir = project.file('mybox')
+                commands.set(['box', 'list'])
+                boxDir.set(project.layout.projectDirectory.dir('mybox'))
             }
 
             task.processExecutor = mockExternalProcessExecutor
@@ -58,8 +58,8 @@ class VagrantSpec extends Specification {
             ExternalProcessExecutionResult result = new ExternalProcessExecutionResult(exitValue: 0, text: 'success')
         when:
             Task task = project.task(TASK_NAME, type: Vagrant) {
-                commands = ['box', 'list']
-                boxDir = project.file('mybox')
+                commands.set(['box', 'list'])
+                boxDir.set(project.layout.projectDirectory.dir('mybox'))
             }
 
             task.processExecutor = mockExternalProcessExecutor

--- a/src/test/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSshSpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantSshSpec.groovy
@@ -38,8 +38,8 @@ class VagrantSshSpec extends Specification {
             ExternalProcessExecutionResult result = new ExternalProcessExecutionResult(exitValue: 1, text: 'failure')
         when:
             Task task = project.task(TASK_NAME, type: VagrantSsh) {
-                sshCommand = "echo 'hello world'"
-                boxDir = project.file('mybox')
+                sshCommand.set("echo 'hello world'")
+                boxDir.set(project.layout.projectDirectory.dir('mybox'))
             }
 
             task.processExecutor = mockExternalProcessExecutor
@@ -58,8 +58,8 @@ class VagrantSshSpec extends Specification {
             ExternalProcessExecutionResult result = new ExternalProcessExecutionResult(exitValue: 0, text: 'success')
         when:
             Task task = project.task(TASK_NAME, type: VagrantSsh) {
-                sshCommand = "echo 'hello world'"
-                boxDir = project.file('mybox')
+                sshCommand.set("echo 'hello world'")
+                boxDir.set(project.layout.projectDirectory.dir('mybox'))
             }
 
             task.processExecutor = mockExternalProcessExecutor

--- a/src/test/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantUpSpec.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/vagrant/tasks/VagrantUpSpec.groovy
@@ -38,9 +38,8 @@ class VagrantUpSpec extends Specification {
             ExternalProcessExecutionResult result = new ExternalProcessExecutionResult(exitValue: 1, text: 'failure')
         when:
             Task task = project.task(TASK_NAME, type: VagrantUp) {
-                commands = ['up']
-                boxDir = project.file('mybox')
-                provider = 'vmware_fusion'
+                boxDir.set(project.layout.projectDirectory.dir('mybox'))
+                provider.set('vmware_fusion')
             }
 
             task.processExecutor = mockExternalProcessExecutor
@@ -59,9 +58,8 @@ class VagrantUpSpec extends Specification {
             ExternalProcessExecutionResult result = new ExternalProcessExecutionResult(exitValue: 0, text: 'success')
         when:
             Task task = project.task(TASK_NAME, type: VagrantUp) {
-                commands = ['up']
-                boxDir = project.file('mybox')
-                provider = 'vmware_fusion'
+                boxDir.set(project.layout.projectDirectory.dir('mybox'))
+                provider.set('vmware_fusion')
             }
 
             task.processExecutor = mockExternalProcessExecutor
@@ -78,8 +76,7 @@ class VagrantUpSpec extends Specification {
             ExternalProcessExecutionResult result = new ExternalProcessExecutionResult(exitValue: 0, text: 'success')
         when:
             Task task = project.task(TASK_NAME, type: VagrantUp) {
-                commands = ['up']
-                boxDir = project.file('mybox')
+                boxDir.set(project.layout.projectDirectory.dir('mybox'))
             }
 
             task.processExecutor = mockExternalProcessExecutor


### PR DESCRIPTION
Changes all tasks to use the provider API instead of plain fields. This
allows for late wiring, e.g. if one wants to set the value of
environmentVariables to a value that is computed by another task.
By doing this all tasks have been made abstract so Gradle will create an
implementation of the task and inject the property instance into it.